### PR TITLE
Update to repository fetchAll() requests to return a more structured PaginatedResults

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Run `composer test`
 
 ```
 Code Coverage Report:      
-  2021-11-08 21:51:05      
+  2021-11-10 12:02:27      
                            
  Summary:                  
-  Classes: 62.50% (15/24)  
-  Methods: 88.10% (185/210)
-  Lines:   90.23% (471/522)
+  Classes: 64.00% (16/25)  
+  Methods: 88.21% (187/212)
+  Lines:   90.43% (482/533)
 ```
 
 ### Contributing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Changelog
 
+### Release v1.1.0 `10/11/2021`
+
+- Added [PaginatedResults](../src/Entity/PaginatedResults.php) to better structure the repository results for `fetchAll()` requests.
+- Updated unit tests to cover this new functionality.
+
 ### Release v1.0.0 `09/11/2021`
 
 Initial application layout.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -60,8 +60,8 @@ try {
 
 ```
 try {
-    /** @var Payment[] $results */
-    $results = $govPayClient
+    /** @var PaginatedResults $paginatedResults */
+    $paginatedResults = $govPayClient
         ->getRepository(Payment::class) /** @var PaymentRepository */
         ->setFromDate('2021-10-01 00:00:00')
         ->setToDate('2021-10-31 23:59:59')
@@ -81,8 +81,8 @@ try {
 
 ```
 try {
-    /** @var Refund[] $results */
-    $results = $govPayClient
+    /** @var PaginatedResults $paginatedResults */
+    $paginatedResults = $govPayClient
         ->getRepository(Refund::class) /** @var RefundRepository */
         ->setFromDate('2021-10-01 00:00:00')
         ->setToDate('2021-10-31 23:59:59')

--- a/example.php
+++ b/example.php
@@ -3,6 +3,7 @@ require_once 'vendor/autoload.php';
 
 use GuzzleHttp\Client as GuzzleClient;
 use LBHounslow\GovPay\Client\Client as GovPayClient;
+use LBHounslow\GovPay\Entity\PaginatedResults;
 use LBHounslow\GovPay\Entity\Payment;
 use LBHounslow\GovPay\Entity\PaymentEvent;
 use LBHounslow\GovPay\Entity\Refund;
@@ -73,15 +74,16 @@ try {
 /*** SEARCH ALL PAYMENTS **/
 
 try {
-    /** @var Payment[] $results */
-    $results = $govPayClient
+    /** @var PaginatedResults $paginatedResults */
+    $paginatedResults = $govPayClient
         ->getRepository(Payment::class) /** @var PaymentRepository */
         ->setFromDate('2021-10-01 00:00:00')
         ->setToDate('2021-10-31 23:59:59')
         ->setPerPage(20)
         ->fetchAll();
 
-    $payment = array_shift($results);  // grab the first one
+    $payments = $paginatedResults->getResults();
+    $payment = array_shift($payments);  // grab the first one
 
     echo $payment->getPaymentId() . ' '
         . $payment->getDescription() . ' '
@@ -94,15 +96,16 @@ try {
 /*** SEARCH ALL REFUNDS **/
 
 try {
-    /** @var Refund[] $results */
-    $results = $govPayClient
+    /** @var PaginatedResults $paginatedResults */
+    $paginatedResults = $govPayClient
         ->getRepository(Refund::class) /** @var RefundRepository */
         ->setFromDate('2021-10-01 00:00:00')
         ->setToDate('2021-10-31 23:59:59')
         ->setPerPage(20)
         ->fetchAll();
 
-    $refund = array_shift($results);  // grab the first one
+    $refunds = $paginatedResults->getResults();
+    $refund = array_shift($refunds);  // grab the first one
 
     echo $refund->getPaymentId() . ' '
         . $refund->getCreatedDate() . ' '

--- a/src/Entity/PaginatedResults.php
+++ b/src/Entity/PaginatedResults.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LBHounslow\GovPay\Entity;
+
+class PaginatedResults implements ArrayToEntityInterface
+{
+    /**
+     * @var int
+     */
+    private $total = 0;
+
+    /**
+     * @var int
+     */
+    private $count = 0;
+
+    /**
+     * @var int
+     */
+    private $page = 1;
+
+    /**
+     * @var array
+     */
+    private $results = [];
+
+    /**
+     * @var string
+     */
+    private $firstPageUri = '';
+
+    /**
+     * @var string
+     */
+    private $currentPageUri = '';
+
+    /**
+     * @var string
+     */
+    private $prevPageUri = '';
+
+    /**
+     * @var string
+     */
+    private $nextPageUri = '';
+
+    /**
+     * @var string
+     */
+    private $lastPageUri = '';
+
+    /**
+     * @return int
+     */
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    /**
+     * @return array
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    /**
+     * @param array $results
+     * @return PaginatedResults
+     */
+    public function setResults(array $results): PaginatedResults
+    {
+        $this->results = $results;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFirstPageUri(): string
+    {
+        return $this->firstPageUri;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentPageUri(): string
+    {
+        return $this->currentPageUri;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrevPageUri(): string
+    {
+        return $this->prevPageUri;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNextPageUri(): string
+    {
+        return $this->nextPageUri;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastPageUri(): string
+    {
+        return $this->lastPageUri;
+    }
+
+    /**
+     * @param array $data
+     * @return $this
+     */
+    public function fromArray(array $data)
+    {
+        if (
+            !isset($data['total'])
+            || !isset($data['count'])
+            || !isset($data['page'])
+        ) {
+            throw new \InvalidArgumentException('Missing pagination attributes');
+        }
+        $this->total = isset($data['total']) ? $data['total'] : $this->total;
+        $this->count = isset($data['count']) ? $data['count'] : $this->count;
+        $this->page = isset($data['page']) ? $data['page'] : $this->page;
+        $this->results = isset($data['results']) ? $data['results'] : $this->results;
+        $this->firstPageUri = isset($data['_links']['first_page']['href']) ? $data['_links']['first_page']['href'] : $this->firstPageUri;
+        $this->currentPageUri = isset($data['_links']['self']['href']) ? $data['_links']['self']['href'] : $this->currentPageUri;
+        $this->prevPageUri = isset($data['_links']['prev_page']['href']) ? $data['_links']['prev_page']['href'] : $this->prevPageUri;
+        $this->nextPageUri = isset($data['_links']['next_page']['href']) ? $data['_links']['next_page']['href'] : $this->nextPageUri;
+        $this->lastPageUri = isset($data['_links']['last_page']['href']) ? $data['_links']['last_page']['href'] : $this->lastPageUri;
+
+        return $this;
+    }
+}

--- a/src/Repository/RefundRepository.php
+++ b/src/Repository/RefundRepository.php
@@ -6,6 +6,7 @@ namespace LBHounslow\GovPay\Repository;
 
 use GuzzleHttp\Exception\GuzzleException;
 use LBHounslow\GovPay\Client\Client;
+use LBHounslow\GovPay\Entity\PaginatedResults;
 use LBHounslow\GovPay\Entity\Refund;
 use LBHounslow\GovPay\Exception\ApiException;
 use LBHounslow\GovPay\Exception\InvalidEntityClassException;
@@ -25,7 +26,7 @@ class RefundRepository extends BaseEntityRepository
     }
 
     /**
-     * @return array
+     * @return PaginatedResults
      * @throws ApiException
      * @throws GuzzleException
      * @throws InvalidEntityClassException
@@ -33,18 +34,22 @@ class RefundRepository extends BaseEntityRepository
      */
     public function fetchAll()
     {
-        $results = [];
-
         /** @var ApiResponse $response */
         $response = $this->client->get(Client::SEARCH_REFUNDS . $this->queryStringBuilder->build());
 
+        $paginatedResults = (new PaginatedResults())
+            ->fromArray($response->getBody());
+
+        $results = [];
+
         /** @var array $row */
-        foreach ($response->fetchAll() as $row) {
+        foreach ($paginatedResults->getResults() as $row) {
             /** @var Refund $refund */
             $refund = (new ArrayToEntityFactory($row, Refund::class))->factory();
             $results[] = $refund;
         }
 
-        return $results;
+        return $paginatedResults
+            ->setResults($results);
     }
 }

--- a/src/Response/ApiResponse.php
+++ b/src/Response/ApiResponse.php
@@ -20,51 +20,6 @@ final class ApiResponse
     private $body;
 
     /**
-     * @var int
-     */
-    private $total = 0;
-
-    /**
-     * @var int
-     */
-    private $count = 0;
-
-    /**
-     * @var int
-     */
-    private $page = 1;
-
-    /**
-     * @var array
-     */
-    private $results = [];
-
-    /**
-     * @var string
-     */
-    private $firstPageUri = '';
-
-    /**
-     * @var string
-     */
-    private $currentPageUri = '';
-
-    /**
-     * @var string
-     */
-    private $prevPageUri = '';
-
-    /**
-     * @var string
-     */
-    private $nextPageUri = '';
-
-    /**
-     * @var string
-     */
-    private $lastPageUri = '';
-
-    /**
      * @var string
      */
     private $field = '';
@@ -97,13 +52,11 @@ final class ApiResponse
     }
 
     /**
-     * Returns single result
-     *
      * @return array
      */
-    public function fetchOne(): array
+    public function getBody(): array
     {
-        return $this->isSuccessful() ? $this->body : [];
+        return $this->body;
     }
 
     /**
@@ -112,78 +65,6 @@ final class ApiResponse
     public function isSuccessful()
     {
         return empty($this->errorCode) && empty($this->code);
-    }
-
-    /**
-     * @return int
-     */
-    public function getTotal(): int
-    {
-        return $this->total;
-    }
-
-    /**
-     * @return int
-     */
-    public function getCount(): int
-    {
-        return $this->count;
-    }
-
-    /**
-     * @return int
-     */
-    public function getPage(): int
-    {
-        return $this->page;
-    }
-
-    /**
-     * @return array
-     */
-    public function fetchAll(): array
-    {
-        return $this->results;
-    }
-
-    /**
-     * @return string
-     */
-    public function getFirstPageUri(): string
-    {
-        return $this->firstPageUri;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCurrentPageUri(): string
-    {
-        return $this->currentPageUri;
-    }
-
-    /**
-     * @return string
-     */
-    public function getNextPageUri(): string
-    {
-        return $this->nextPageUri;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPrevPageUri(): string
-    {
-        return $this->prevPageUri;
-    }
-
-    /**
-     * @return string
-     */
-    public function getLastPageUri(): string
-    {
-        return $this->lastPageUri;
     }
 
     /**
@@ -226,24 +107,14 @@ final class ApiResponse
         }
 
         $this->body = json_decode($body, true);
+        $this->body = isset($this->body['events']) ? $this->body['events'] : $this->body;
+        $this->body = isset($this->body['_embedded']['refunds']) ? $this->body['_embedded']['refunds'] : $this->body;
 
         if (isset($this->body['code']) && isset($this->body['description'])) {
             $this->field = isset($this->body['field']) ? $this->body['field'] : $this->field;
             $this->code = $this->body['code'];
             $this->description = $this->body['description'];
         }
-
-        $this->total = isset($this->body['total']) ? $this->body['total'] : $this->total;
-        $this->count = isset($this->body['count']) ? $this->body['count'] : $this->count;
-        $this->page = isset($this->body['page']) ? $this->body['page'] : $this->page;
-        $this->results = isset($this->body['results']) ? $this->body['results'] : $this->results;
-        $this->results = isset($this->body['events']) ? $this->body['events'] : $this->results;
-        $this->results = isset($this->body['_embedded']['refunds']) ? $this->body['_embedded']['refunds'] : $this->results;
-        $this->firstPageUri = isset($this->body['_links']['first_page']['href']) ? $this->body['_links']['first_page']['href'] : $this->firstPageUri;
-        $this->currentPageUri = isset($this->body['_links']['self']['href']) ? $this->body['_links']['self']['href'] : $this->currentPageUri;
-        $this->prevPageUri = isset($this->body['_links']['prev_page']['href']) ? $this->body['_links']['prev_page']['href'] : $this->prevPageUri;
-        $this->nextPageUri = isset($this->body['_links']['next_page']['href']) ? $this->body['_links']['next_page']['href'] : $this->nextPageUri;
-        $this->lastPageUri = isset($this->body['_links']['last_page']['href']) ? $this->body['_links']['last_page']['href'] : $this->lastPageUri;
     }
 
     /**

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -145,9 +145,9 @@ abstract class AbstractTestCase extends TestCase
     ];
 
     const SEARCH_RESULTS_EMPTY_ARRAY = [
-        'total' => self::SEARCH_RESULTS_TOTAL,
-        'count' => self::SEARCH_RESULTS_COUNT,
-        'page' => self::SEARCH_RESULTS_PAGE,
+        'total' => 0,
+        'count' => 0,
+        'page' => 1,
         'results' => []
     ];
 

--- a/tests/unit/Client/ClientTest.php
+++ b/tests/unit/Client/ClientTest.php
@@ -83,15 +83,15 @@ class ClientTest extends AbstractTestCase
 
         $this->assertInstanceOf(ApiResponse::class, $apiResponse);
         $this->assertEquals($isSuccessful, $apiResponse->isSuccessful());
-        $this->assertEquals($expectedPayload, $apiResponse->fetchOne());
+        $this->assertEquals($expectedPayload, $apiResponse->getBody());
     }
 
     public function successfulPostResponseDataProvider()
     {
         return [
             [new GuzzleResponse(HttpStatusCodeEnum::OK, [], json_encode(self::PAYMENT_ARRAY)), true, self::PAYMENT_ARRAY],
-            [new GuzzleResponse(HttpStatusCodeEnum::BAD_REQUEST, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD)), false, []],
-            [new GuzzleResponse(HttpStatusCodeEnum::INTERNAL_SERVER_ERROR, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD)), false, []]
+            [new GuzzleResponse(HttpStatusCodeEnum::BAD_REQUEST, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD)), false, self::ERROR_RESPONSE_WITH_FIELD],
+            [new GuzzleResponse(HttpStatusCodeEnum::INTERNAL_SERVER_ERROR, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD)), false, self::ERROR_RESPONSE_WITH_FIELD]
         ];
     }
 
@@ -122,15 +122,15 @@ class ClientTest extends AbstractTestCase
 
         $this->assertInstanceOf(ApiResponse::class, $apiResponse);
         $this->assertEquals($isSuccessful, $apiResponse->isSuccessful());
-        $this->assertEquals($expectedPayload, $apiResponse->fetchOne());
+        $this->assertEquals($expectedPayload, $apiResponse->getBody());
     }
 
     public function successfulGetResponseDataProvider()
     {
         return [
             [new GuzzleResponse(HttpStatusCodeEnum::OK, [], json_encode(self::PAYMENT_ARRAY)), true, self::PAYMENT_ARRAY],
-            [new GuzzleResponse(HttpStatusCodeEnum::BAD_REQUEST, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD)), false, []],
-            [new GuzzleResponse(HttpStatusCodeEnum::INTERNAL_SERVER_ERROR, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD)), false, []]
+            [new GuzzleResponse(HttpStatusCodeEnum::BAD_REQUEST, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD)), false, self::ERROR_RESPONSE_WITH_FIELD],
+            [new GuzzleResponse(HttpStatusCodeEnum::INTERNAL_SERVER_ERROR, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD)), false, self::ERROR_RESPONSE_WITH_FIELD]
         ];
     }
 }

--- a/tests/unit/Entity/PaginatedResultsTest.php
+++ b/tests/unit/Entity/PaginatedResultsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Entity;
+
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LBHounslow\GovPay\Entity\PaginatedResults;
+use LBHounslow\GovPay\Enum\HttpStatusCodeEnum;
+use LBHounslow\GovPay\Response\ApiResponse;
+use Tests\Unit\AbstractTestCase;
+
+class PaginatedResultsTest extends AbstractTestCase
+{
+    /**
+     * @var PaginatedResults
+     */
+    private $paginatedResults;
+
+    public function setUp(): void
+    {
+        $this->paginatedResults = new PaginatedResults();
+        parent::setUp();
+    }
+
+    public function testItThrowsExceptionForNonPaginatedResults()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->paginatedResults->fromArray(['invalid' => 'array', 'structure']);
+    }
+
+    public function testItSetsAttributesCorrectlyForEmptySearchResponse()
+    {
+        $apiResponse = new ApiResponse(
+            new GuzzleResponse(HttpStatusCodeEnum::OK, [], json_encode(self::SEARCH_RESULTS_EMPTY_ARRAY))
+        );
+        /** @var PaginatedResults $result */
+        $result = $this->paginatedResults->fromArray($apiResponse->getBody());
+        $this->assertEquals(0, $result->getTotal());
+        $this->assertEquals(0, $result->getCount());
+        $this->assertEquals(1, $result->getPage());
+        $this->assertEquals([], $result->getResults());
+        $this->assertEmpty($result->getCurrentPageUri());
+        $this->assertEmpty($result->getFirstPageUri());
+        $this->assertEmpty($result->getPrevPageUri());
+        $this->assertEmpty($result->getNextPageUri());
+        $this->assertEmpty($result->getLastPageUri());
+    }
+
+    public function testItSetsAttributesCorrectlyForValidApiSearchResponse()
+    {
+        $apiResponse = new ApiResponse(
+            new GuzzleResponse(HttpStatusCodeEnum::OK, [], json_encode(self::PAYMENT_SEARCH_RESULTS_ARRAY))
+        );
+        /** @var PaginatedResults $result */
+        $result = $this->paginatedResults->fromArray($apiResponse->getBody());
+        $this->assertEquals(self::SEARCH_RESULTS_TOTAL, $result->getTotal());
+        $this->assertEquals(self::SEARCH_RESULTS_COUNT, $result->getCount());
+        $this->assertEquals(self::SEARCH_RESULTS_PAGE, $result->getPage());
+        $this->assertEquals(self::SEARCH_LINKS_SELF_HREF, $result->getCurrentPageUri());
+        $this->assertEquals(self::SEARCH_LINKS_FIRST_HREF, $result->getFirstPageUri());
+        $this->assertEquals(self::SEARCH_LINKS_PREV_HREF, $result->getPrevPageUri());
+        $this->assertEquals(self::SEARCH_LINKS_NEXT_HREF, $result->getNextPageUri());
+        $this->assertEquals(self::SEARCH_LINKS_LAST_HREF, $result->getLastPageUri());
+        $this->assertEquals(self::PAYMENT_ARRAY, $result->getResults()[0]);
+    }
+}

--- a/tests/unit/Response/ApiResponseTest.php
+++ b/tests/unit/Response/ApiResponseTest.php
@@ -49,15 +49,15 @@ class ApiResponseTest extends AbstractTestCase
         $this->assertEquals(self::ERROR_DESCRIPTION, $apiResponse->getErrorDescription());
     }
 
-    public function testItReturnsStructuredResponseForSingleRecordResponse()
+    public function testThatGetBodyIsPopulatedForSingleRecordResponse()
     {
         $apiResponse = new ApiResponse(
             new GuzzleResponse(HttpStatusCodeEnum::OK, [], json_encode(self::PAYMENT_ARRAY))
         );
         $this->assertTrue($apiResponse->isSuccessful());
-        $this->assertIsArray($apiResponse->fetchOne());
-        $this->assertArrayHasKey('amount', $apiResponse->fetchOne());
-        $this->assertEquals($apiResponse->fetchOne()['amount'], self::PAYMENT_AMOUNT);
+        $this->assertIsArray($apiResponse->getBody());
+        $this->assertArrayHasKey('amount', $apiResponse->getBody());
+        $this->assertEquals($apiResponse->getBody()['amount'], self::PAYMENT_AMOUNT);
     }
 
     public function testItReturnsStructuredResponseForEmptySearchResponse()
@@ -66,8 +66,8 @@ class ApiResponseTest extends AbstractTestCase
             new GuzzleResponse(HttpStatusCodeEnum::OK, [], json_encode([]))
         );
         $this->assertTrue($apiResponse->isSuccessful());
-        $this->assertIsArray($apiResponse->fetchAll());
-        $this->assertEmpty($apiResponse->fetchAll());
+        $this->assertIsArray($apiResponse->getBody());
+        $this->assertEquals([], $apiResponse->getBody());
     }
 
     public function testItReturnsStructuredResponseForSearchResponse()
@@ -76,16 +76,8 @@ class ApiResponseTest extends AbstractTestCase
             new GuzzleResponse(HttpStatusCodeEnum::OK, [], json_encode(self::PAYMENT_SEARCH_RESULTS_ARRAY))
         );
         $this->assertTrue($apiResponse->isSuccessful());
-        $this->assertIsArray($apiResponse->fetchAll());
-        $this->assertNotEmpty($apiResponse->fetchAll());
-        $this->assertEquals(self::SEARCH_RESULTS_COUNT, $apiResponse->getCount());
-        $this->assertEquals(self::SEARCH_RESULTS_PAGE, $apiResponse->getPage());
-        $this->assertEquals(self::SEARCH_RESULTS_TOTAL, $apiResponse->getTotal());
-        $this->assertEquals(self::SEARCH_LINKS_SELF_HREF, $apiResponse->getCurrentPageUri());
-        $this->assertEquals(self::SEARCH_LINKS_FIRST_HREF, $apiResponse->getFirstPageUri());
-        $this->assertEquals(self::SEARCH_LINKS_PREV_HREF, $apiResponse->getPrevPageUri());
-        $this->assertEquals(self::SEARCH_LINKS_NEXT_HREF, $apiResponse->getNextPageUri());
-        $this->assertEquals(self::SEARCH_LINKS_LAST_HREF, $apiResponse->getLastPageUri());
-        $this->assertEquals(self::PAYMENT_ARRAY, $apiResponse->fetchAll()[0]);
+        $this->assertIsArray($apiResponse->getBody());
+        $this->assertNotEmpty($apiResponse->getBody());
+        $this->assertEquals(self::PAYMENT_SEARCH_RESULTS_ARRAY, $apiResponse->getBody());
     }
 }


### PR DESCRIPTION
The original structure of the [ApiResponse](https://github.com/LBHounslow/govpay-client/commit/8281c98edc091778d10821abac449a71afd62587#diff-757489174e7885a6a89bc24e5abf6a89595a8793d1068eb30cde09fb5911393e) is to store pagination related attributes from the GOV.UK api response. However the repository `fetchAll()` methods do not return any of this pagination data. This change is to add a structured response for `fetchAll()` requests that includes pagination attributes.

- Added [PaginatedResults](https://github.com/LBHounslow/govpay-client/blob/feature-create-structured-paginated-response/src/Entity/PaginatedResults.php) (and unit [test](https://github.com/LBHounslow/govpay-client/blob/feature-create-structured-paginated-response/tests/unit/Entity/PaginatedResultsTest.php)) that contains the relevant pagination attributes.
- This required updates to [PaymentRepository](https://github.com/LBHounslow/govpay-client/blob/feature-create-structured-paginated-response/src/Repository/PaymentRepository.php#L174) and [RefundRepository](https://github.com/LBHounslow/govpay-client/blob/feature-create-structured-paginated-response/src/Repository/RefundRepository.php#L35) fetchAll() methods (and updates to the relevant unit tests and documentation)

```
govpay-client % composer test
> ./vendor/bin/phpunit tests --colors
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.25
Configuration: /Users/brett/Code/govpay-client/phpunit.xml.dist

...............................................................  63 / 101 ( 62%)
......................................                          101 / 101 (100%)

Time: 00:00.067, Memory: 10.00 MB

OK (101 tests, 266 assertions)
```

