### PR TITLE
Release v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Run `composer test`
 
 ```
 Code Coverage Report:      
-  2021-11-10 12:02:27      
+  2021-12-09 13:43:46      
                            
  Summary:                  
-  Classes: 64.00% (16/25)  
-  Methods: 88.21% (187/212)
-  Lines:   90.43% (482/533)
+  Classes: 65.38% (17/26)  
+  Methods: 87.61% (191/218)
+  Lines:   90.76% (501/552)
 ```
 
 ### Contributing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Changelog
 
+### Release v1.2.0 `09/12/2021`
+
+Updates:
+- Added [ApiErrorResponseException](../src/Exception/ApiErrorResponseException.php) which takes `ApiResponse` as an argument and stores (and provides) error response information from the GOV.UK api.
+- Updated `PaymentRepository` and `RefundRepository` to throw this exception for an unsuccessful api response (`!ApiResponse.isSuccessful()`).
+- Updated unit tests and documentation to cover this new exception.
+- Removed incorrect @throws tags from `post` and `get` methods in [Client](../src/Client/Client.php).
+
+Fixes:
+- Added default empty string value for `paymentId` attribute in [Refund](../src/Entity/Refund.php) entity.
+- Added unit test coverage in [RefundTest](../tests/unit/Entity/RefundTest.php) for both empty and populated `paymentId` attribute.
+
 ### Release v1.1.0 `10/11/2021`
 
 - Added [PaginatedResults](../src/Entity/PaginatedResults.php) to better structure the repository results for `fetchAll()` requests.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -21,8 +21,16 @@ try {
         ->getRepository(Payment::class) /** @var PaymentRepository */
         ->find('INSERT-PAYMENT-ID');
 
+} catch (ApiErrorResponseException $ae) {
+    // Handle
+    // $ae->getApiResponse()
+    // $ae->getErrorDescription()
+    // $ae->getErrorCode()
+    // $ae->getErrorField()
 } catch (\Exception $e) {
     // Handle $e
+    // ApiException
+    // InvalidEntityClassException
 }
 ```
 
@@ -35,8 +43,16 @@ try {
         ->getRepository(Payment::class) /** @var PaymentRepository */
         ->fetchPaymentEvents('INSERT-PAYMENT-ID');
 
+} catch (ApiErrorResponseException $ae) {
+    // Handle
+    // $ae->getApiResponse()
+    // $ae->getErrorDescription()
+    // $ae->getErrorCode()
+    // $ae->getErrorField()
 } catch (\Exception $e) {
     // Handle $e
+    // ApiException
+    // InvalidEntityClassException
 }
 ```
 
@@ -49,8 +65,16 @@ try {
         ->getRepository(Payment::class) /** @var PaymentRepository */
         ->fetchPaymentRefunds('INSERT-PAYMENT-ID');
 
+} catch (ApiErrorResponseException $ae) {
+    // Handle
+    // $ae->getApiResponse()
+    // $ae->getErrorDescription()
+    // $ae->getErrorCode()
+    // $ae->getErrorField()
 } catch (\Exception $e) {
     // Handle $e
+    // ApiException
+    // InvalidEntityClassException
 }
 ```
 
@@ -68,8 +92,17 @@ try {
         ->setPerPage(20)
         ->fetchAll();
 
+} catch (ApiErrorResponseException $ae) {
+    // Handle
+    // $ae->getApiResponse()
+    // $ae->getErrorDescription()
+    // $ae->getErrorCode()
+    // $ae->getErrorField()
 } catch (\Exception $e) {
     // Handle $e
+    // ApiException
+    // InvalidEntityClassException
+    // ValidationException
 }
 ```
 
@@ -89,8 +122,17 @@ try {
         ->setPerPage(20)
         ->fetchAll();
 
+} catch (ApiErrorResponseException $ae) {
+    // Handle
+    // $ae->getApiResponse()
+    // $ae->getErrorDescription()
+    // $ae->getErrorCode()
+    // $ae->getErrorField()
 } catch (\Exception $e) {
     // Handle $e
+    // ApiException
+    // InvalidEntityClassException
+    // ValidationException
 }
 ```
 

--- a/example.php
+++ b/example.php
@@ -7,6 +7,7 @@ use LBHounslow\GovPay\Entity\PaginatedResults;
 use LBHounslow\GovPay\Entity\Payment;
 use LBHounslow\GovPay\Entity\PaymentEvent;
 use LBHounslow\GovPay\Entity\Refund;
+use LBHounslow\GovPay\Exception\ApiErrorResponseException;
 use LBHounslow\GovPay\Repository\PaymentRepository;
 use LBHounslow\GovPay\Repository\RefundRepository;
 
@@ -29,9 +30,16 @@ try {
     echo $payment->getPaymentId() . ' '
         . $payment->getDescription() . ' '
         . $payment->getCreatedDate() . PHP_EOL;
-
+} catch (ApiErrorResponseException $ae) {
+    // Handle
+    // $ae->getApiResponse()
+    // $ae->getErrorDescription()
+    // $ae->getErrorCode()
+    // $ae->getErrorField()
 } catch (\Exception $e) {
     // Handle $e
+    // ApiException
+    // InvalidEntityClassException
 }
 
 /*** FETCH A PAYMENTS EVENTS **/
@@ -48,8 +56,16 @@ try {
         . $paymentEvent->getState()->getStatus()
         . ($paymentEvent->getState()->isFinished() ? ' is finished' : '') . PHP_EOL;
 
+} catch (ApiErrorResponseException $ae) {
+    // Handle
+    // $ae->getApiResponse()
+    // $ae->getErrorDescription()
+    // $ae->getErrorCode()
+    // $ae->getErrorField()
 } catch (\Exception $e) {
     // Handle $e
+    // ApiException
+    // InvalidEntityClassException
 }
 
 /*** FETCH A PAYMENTS REFUNDS **/
@@ -67,8 +83,16 @@ try {
         . $refund->getAmount() . ' '
         . $refund->getStatus() . PHP_EOL;
 
+} catch (ApiErrorResponseException $ae) {
+    // Handle
+    // $ae->getApiResponse()
+    // $ae->getErrorDescription()
+    // $ae->getErrorCode()
+    // $ae->getErrorField()
 } catch (\Exception $e) {
     // Handle $e
+    // ApiException
+    // InvalidEntityClassException
 }
 
 /*** SEARCH ALL PAYMENTS **/
@@ -89,8 +113,16 @@ try {
         . $payment->getDescription() . ' '
         . $payment->getCreatedDate() . PHP_EOL;
 
+} catch (ApiErrorResponseException $ae) {
+    // Handle
+    // $ae->getApiResponse()
+    // $ae->getErrorDescription()
+    // $ae->getErrorCode()
+    // $ae->getErrorField()
 } catch (\Exception $e) {
     // Handle $e
+    // ApiException
+    // InvalidEntityClassException
 }
 
 /*** SEARCH ALL REFUNDS **/
@@ -112,7 +144,16 @@ try {
         . $refund->getAmount() . ' '
         . $refund->getStatus() . PHP_EOL;
 
+} catch (ApiErrorResponseException $ae) {
+    // Handle
+    // $ae->getApiResponse()
+    // $ae->getErrorDescription()
+    // $ae->getErrorCode()
+    // $ae->getErrorField()
 } catch (\Exception $e) {
     // Handle $e
+    // ApiException
+    // InvalidEntityClassException
+    // ValidationException
 }
 

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LBHounslow\GovPay\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use GuzzleHttp\RequestOptions;
 use LBHounslow\GovPay\Enum\HttpStatusCodeEnum;
@@ -69,8 +68,6 @@ class Client
      * @param array $data
      * @return ApiResponse
      * @throws ApiException
-     * @throws GuzzleException
-     * @throws \Exception
      */
     public function post(string $endpoint, array $data = [])
     {
@@ -102,8 +99,6 @@ class Client
      * @param string $endpoint
      * @return ApiResponse
      * @throws ApiException
-     * @throws GuzzleException
-     * @throws \Exception
      */
     public function get(string $endpoint)
     {

--- a/src/Entity/Refund.php
+++ b/src/Entity/Refund.php
@@ -9,7 +9,7 @@ class Refund implements ArrayToEntityInterface
     /**
      * @var string
      */
-    private $paymentId;
+    private $paymentId = '';
 
     /**
      * @var string

--- a/src/Exception/ApiErrorResponseException.php
+++ b/src/Exception/ApiErrorResponseException.php
@@ -35,16 +35,6 @@ class ApiErrorResponseException extends \Exception
     }
 
     /**
-     * @param ApiResponse $apiResponse
-     * @return ApiErrorResponseException
-     */
-    public function setApiResponse(ApiResponse $apiResponse): ApiErrorResponseException
-    {
-        $this->apiResponse = $apiResponse;
-        return $this;
-    }
-
-    /**
      * @return string
      */
     public function getErrorDescription(): string

--- a/src/Exception/ApiErrorResponseException.php
+++ b/src/Exception/ApiErrorResponseException.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace LBHounslow\GovPay\Exception;
+
+use LBHounslow\GovPay\Response\ApiResponse;
+use Throwable;
+
+class ApiErrorResponseException extends \Exception
+{
+    /**
+     * @var ApiResponse
+     */
+    private $apiResponse;
+
+    /**
+     * @param ApiResponse $apiResponse
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        ApiResponse $apiResponse,
+        $code = 0,
+        Throwable $previous = null
+    ) {
+        $this->apiResponse = $apiResponse;
+        parent::__construct($apiResponse->getErrorDescription(), $code, $previous);
+    }
+
+    /**
+     * @return ApiResponse
+     */
+    public function getApiResponse(): ApiResponse
+    {
+        return $this->apiResponse;
+    }
+
+    /**
+     * @param ApiResponse $apiResponse
+     * @return ApiErrorResponseException
+     */
+    public function setApiResponse(ApiResponse $apiResponse): ApiErrorResponseException
+    {
+        $this->apiResponse = $apiResponse;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorDescription(): string
+    {
+        return $this->apiResponse->getErrorDescription();
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorCode(): string
+    {
+        return $this->apiResponse->getErrorCode();
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorField(): string
+    {
+        return $this->apiResponse->getErrorField();
+    }
+}

--- a/src/Repository/PaymentRepository.php
+++ b/src/Repository/PaymentRepository.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace LBHounslow\GovPay\Repository;
 
-use GuzzleHttp\Exception\GuzzleException;
 use LBHounslow\GovPay\Client\Client;
 use LBHounslow\GovPay\Entity\PaginatedResults;
 use LBHounslow\GovPay\Entity\Payment;
 use LBHounslow\GovPay\Entity\PaymentEvent;
 use LBHounslow\GovPay\Entity\Refund;
+use LBHounslow\GovPay\Exception\ApiErrorResponseException;
 use LBHounslow\GovPay\Exception\ApiException;
 use LBHounslow\GovPay\Exception\InvalidEntityClassException;
 use LBHounslow\GovPay\Exception\ValidationException;
@@ -100,14 +100,18 @@ class PaymentRepository extends BaseEntityRepository
     /**
      * @param string $id
      * @return Payment
+     * @throws ApiErrorResponseException
      * @throws ApiException
-     * @throws GuzzleException
      * @throws InvalidEntityClassException
      */
     public function find(string $id)
     {
         /** @var ApiResponse $response */
         $response = $this->client->get(sprintf(Client::PAYMENT, $id));
+
+        if (!$response->isSuccessful()) {
+            throw new ApiErrorResponseException($response);
+        }
 
         /** @var Payment $payment */
         $payment = (new ArrayToEntityFactory($response->getBody(), Payment::class))->factory();
@@ -118,8 +122,8 @@ class PaymentRepository extends BaseEntityRepository
     /**
      * @param string $id
      * @return array
+     * @throws ApiErrorResponseException
      * @throws ApiException
-     * @throws GuzzleException
      * @throws InvalidEntityClassException
      */
     public function fetchPaymentEvents(string $id)
@@ -128,6 +132,10 @@ class PaymentRepository extends BaseEntityRepository
 
         /** @var ApiResponse $response */
         $response = $this->client->get(sprintf(Client::PAYMENT_EVENTS, $id));
+
+        if (!$response->isSuccessful()) {
+            throw new ApiErrorResponseException($response);
+        }
 
         /** @var array $row */
         foreach ($response->getBody() as $row) {
@@ -142,8 +150,8 @@ class PaymentRepository extends BaseEntityRepository
     /**
      * @param string $id
      * @return array
+     * @throws ApiErrorResponseException
      * @throws ApiException
-     * @throws GuzzleException
      * @throws InvalidEntityClassException
      */
     public function fetchPaymentRefunds(string $id)
@@ -152,6 +160,10 @@ class PaymentRepository extends BaseEntityRepository
 
         /** @var ApiResponse $response */
         $response = $this->client->get(sprintf(Client::PAYMENT_REFUNDS, $id));
+
+        if (!$response->isSuccessful()) {
+            throw new ApiErrorResponseException($response);
+        }
 
         /** @var array $row */
         foreach ($response->getBody() as $row) {
@@ -166,8 +178,8 @@ class PaymentRepository extends BaseEntityRepository
 
     /**
      * @return PaginatedResults
+     * @throws ApiErrorResponseException
      * @throws ApiException
-     * @throws GuzzleException
      * @throws InvalidEntityClassException
      * @throws ValidationException
      */
@@ -175,6 +187,10 @@ class PaymentRepository extends BaseEntityRepository
     {
         /** @var ApiResponse $response */
         $response = $this->client->get(Client::SEARCH_PAYMENTS . $this->queryStringBuilder->build());
+
+        if (!$response->isSuccessful()) {
+            throw new ApiErrorResponseException($response);
+        }
 
         $paginatedResults = (new PaginatedResults())
             ->fromArray($response->getBody());

--- a/src/Repository/RefundRepository.php
+++ b/src/Repository/RefundRepository.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace LBHounslow\GovPay\Repository;
 
-use GuzzleHttp\Exception\GuzzleException;
 use LBHounslow\GovPay\Client\Client;
 use LBHounslow\GovPay\Entity\PaginatedResults;
 use LBHounslow\GovPay\Entity\Refund;
+use LBHounslow\GovPay\Exception\ApiErrorResponseException;
 use LBHounslow\GovPay\Exception\ApiException;
 use LBHounslow\GovPay\Exception\InvalidEntityClassException;
 use LBHounslow\GovPay\Exception\ValidationException;
@@ -27,8 +27,8 @@ class RefundRepository extends BaseEntityRepository
 
     /**
      * @return PaginatedResults
+     * @throws ApiErrorResponseException
      * @throws ApiException
-     * @throws GuzzleException
      * @throws InvalidEntityClassException
      * @throws ValidationException
      */
@@ -36,6 +36,10 @@ class RefundRepository extends BaseEntityRepository
     {
         /** @var ApiResponse $response */
         $response = $this->client->get(Client::SEARCH_REFUNDS . $this->queryStringBuilder->build());
+
+        if (!$response->isSuccessful()) {
+            throw new ApiErrorResponseException($response);
+        }
 
         $paginatedResults = (new PaginatedResults())
             ->fromArray($response->getBody());

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -183,12 +183,13 @@ abstract class AbstractTestCase extends TestCase
     ];
 
     const REFUND_REFUND_ID = 'act4c33g40j3edfmi8jknab84x';
+    const REFUND_PAYMENT_ID = '5chu1yzxglqajfv97ous23s22i';
     const REFUND_CREATED_DATE = '2021-11-07T14:08:26.988Z';
     const REFUND_AMOUNT = 120;
     const REFUND_STATUS_SUCCESS = 'success';
     const REFUND_SETTLEMENT_SUMMARY_SETTLED_DATE = '2021-11-06';
 
-    const REFUND_ARRAY = [
+    const REFUND_ARRAY_NO_PAYMENT_LINK = [
         'refund_id' => self::REFUND_REFUND_ID,
         'created_date' => self::REFUND_CREATED_DATE,
         'amount' => self::REFUND_AMOUNT,
@@ -198,11 +199,36 @@ abstract class AbstractTestCase extends TestCase
         ]
     ];
 
-    const PAYMENT_REFUNDS_RESULTS_ARRAY = [
+    const REFUND_ARRAY_WITH_PAYMENT_LINK = [
+        'refund_id' => self::REFUND_REFUND_ID,
+        'created_date' => self::REFUND_CREATED_DATE,
+        'amount' => self::REFUND_AMOUNT,
+        'status' => self::REFUND_STATUS_SUCCESS,
+        'settlement_summary' => [
+            'settled_date' => self::REFUND_SETTLEMENT_SUMMARY_SETTLED_DATE
+        ],
+        '_links' => [
+            'payment' => [
+                'href' => 'https://publicapi.payments.service.gov.uk/v1/payments/5chu1yzxglqajfv97ous23s22i',
+                'method' => 'GET',
+            ]
+        ]
+    ];
+
+    const PAYMENT_REFUNDS_RESULTS_ARRAY_NO_PAYMENT_LINK = [
         'payment_id' => self::PAYMENT_PAYMENT_ID,
         '_embedded' => [
             'refunds' => [
-                self::REFUND_ARRAY
+                self::REFUND_ARRAY_NO_PAYMENT_LINK
+            ]
+        ]
+    ];
+
+    const PAYMENT_REFUNDS_RESULTS_ARRAY_WITH_PAYMENT_LINK = [
+        'payment_id' => self::PAYMENT_PAYMENT_ID,
+        '_embedded' => [
+            'refunds' => [
+                self::REFUND_ARRAY_WITH_PAYMENT_LINK
             ]
         ]
     ];
@@ -212,7 +238,7 @@ abstract class AbstractTestCase extends TestCase
         'count' => self::SEARCH_RESULTS_COUNT,
         'page' => self::SEARCH_RESULTS_PAGE,
         'results' => [
-            self::REFUND_ARRAY
+            self::REFUND_ARRAY_WITH_PAYMENT_LINK
         ],
         '_links' => [
             'self' => [

--- a/tests/unit/Entity/RefundTest.php
+++ b/tests/unit/Entity/RefundTest.php
@@ -26,10 +26,22 @@ class RefundTest extends AbstractTestCase
         $this->assertInstanceOf(Refund::class, $result);
     }
 
-    public function testThatEntityLoadsRefundSummaryDataCorrectly()
+    public function testThatEntityLoadsRefundSummaryDataCorrectlyWithoutPayment()
     {
-        $result = $this->refund->fromArray(self::REFUND_ARRAY);
+        $result = $this->refund->fromArray(self::REFUND_ARRAY_NO_PAYMENT_LINK);
         $this->assertEquals(self::REFUND_REFUND_ID, $result->getRefundId());
+        $this->assertEquals('', $result->getPaymentId());
+        $this->assertEquals(self::REFUND_CREATED_DATE, $result->getCreatedDate());
+        $this->assertEquals(self::REFUND_AMOUNT, $result->getAmount());
+        $this->assertEquals(self::REFUND_STATUS_SUCCESS, $result->getStatus());
+        $this->assertEquals(self::REFUND_SETTLEMENT_SUMMARY_SETTLED_DATE, $result->getSettlementSummary()->getSettledDate());
+    }
+
+    public function testThatEntityLoadsRefundSummaryDataCorrectlyWithPayment()
+    {
+        $result = $this->refund->fromArray(self::REFUND_ARRAY_WITH_PAYMENT_LINK);
+        $this->assertEquals(self::REFUND_REFUND_ID, $result->getRefundId());
+        $this->assertEquals(self::REFUND_PAYMENT_ID, $result->getPaymentId());
         $this->assertEquals(self::REFUND_CREATED_DATE, $result->getCreatedDate());
         $this->assertEquals(self::REFUND_AMOUNT, $result->getAmount());
         $this->assertEquals(self::REFUND_STATUS_SUCCESS, $result->getStatus());

--- a/tests/unit/Exception/ApiErrorResponseExceptionTest.php
+++ b/tests/unit/Exception/ApiErrorResponseExceptionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Exception;
+
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LBHounslow\GovPay\Enum\HttpStatusCodeEnum;
+use LBHounslow\GovPay\Exception\ApiErrorResponseException;
+use LBHounslow\GovPay\Response\ApiResponse;
+use Tests\Unit\AbstractTestCase;
+
+class ApiErrorResponseExceptionTest extends AbstractTestCase
+{
+    public function testItSetsExceptionBodyCorrectly()
+    {
+        $apiResponse = new ApiResponse(
+            new GuzzleResponse(HttpStatusCodeEnum::BAD_REQUEST, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD))
+        );
+
+        $result = new ApiErrorResponseException($apiResponse);
+        $this->assertInstanceOf(\Exception::class, $result);
+        $this->assertInstanceOf(ApiResponse::class, $result->getApiResponse());
+        $this->assertInstanceOf(GuzzleResponse::class, $result->getApiResponse()->getGuzzleResponse());
+        $this->assertEquals(HttpStatusCodeEnum::BAD_REQUEST, $result->getApiResponse()->getGuzzleResponse()->getStatusCode());
+        $this->assertFalse($result->getApiResponse()->isSuccessful());
+        $this->assertEquals(self::ERROR_RESPONSE_WITH_FIELD, $result->getApiResponse()->getBody());
+        $this->assertEquals(self::ERROR_FIELD, $result->getApiResponse()->getErrorField());
+        $this->assertEquals(self::ERROR_CODE, $result->getApiResponse()->getErrorCode());
+        $this->assertEquals(self::ERROR_DESCRIPTION, $result->getApiResponse()->getErrorDescription());
+    }
+}

--- a/tests/unit/Factory/ArrayToEntityFactoryTest.php
+++ b/tests/unit/Factory/ArrayToEntityFactoryTest.php
@@ -36,9 +36,10 @@ class ArrayToEntityFactoryTest extends AbstractTestCase
 
     public function testItReturnsPopulatedClassInstanceFromEntityClassNameWithData()
     {
-        $result = (new ArrayToEntityFactory(self::REFUND_ARRAY, Refund::class))->factory();
+        $result = (new ArrayToEntityFactory(self::REFUND_ARRAY_WITH_PAYMENT_LINK, Refund::class))->factory();
         $this->assertInstanceOf(Refund::class, $result);
         $this->assertEquals(self::REFUND_REFUND_ID, $result->getRefundId());
+        $this->assertEquals(self::REFUND_PAYMENT_ID, $result->getPaymentId());
         $this->assertEquals(self::REFUND_CREATED_DATE, $result->getCreatedDate());
         $this->assertEquals(self::REFUND_AMOUNT, $result->getAmount());
         $this->assertEquals(self::REFUND_STATUS_SUCCESS, $result->getStatus());

--- a/tests/unit/Repository/PaymentRepositoryTest.php
+++ b/tests/unit/Repository/PaymentRepositoryTest.php
@@ -11,6 +11,7 @@ use LBHounslow\GovPay\Entity\Payment;
 use LBHounslow\GovPay\Entity\PaymentEvent;
 use LBHounslow\GovPay\Entity\Refund;
 use LBHounslow\GovPay\Enum\HttpStatusCodeEnum;
+use LBHounslow\GovPay\Exception\ApiErrorResponseException;
 use LBHounslow\GovPay\Repository\PaymentRepository;
 use LBHounslow\GovPay\Response\ApiResponse;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -43,6 +44,20 @@ class PaymentRepositoryTest extends AbstractTestCase
         $this->assertEquals(Payment::class, $this->paymentRepository->getEntityClass());
     }
 
+    public function testThatFindThrowsApiErrorExceptionForErrorResponse()
+    {
+        $this->expectException(ApiErrorResponseException::class);
+        $this->expectExceptionMessage(self::ERROR_DESCRIPTION);
+        $this->mockGovPayClient
+            ->method('get')
+            ->willReturn(
+                new ApiResponse(
+                    new GuzzleResponse(HttpStatusCodeEnum::BAD_REQUEST, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD))
+                )
+            );
+        $this->paymentRepository->find(self::PAYMENT_PAYMENT_ID);
+    }
+
     public function testItFindsAndReturnsSinglePaymentEntity()
     {
         $this->mockGovPayClient
@@ -55,6 +70,20 @@ class PaymentRepositoryTest extends AbstractTestCase
         $result = $this->paymentRepository->find(self::PAYMENT_PAYMENT_ID);
         $this->assertInstanceOf(Payment::class, $result);
         $this->assertEquals(self::PAYMENT_PAYMENT_ID, $result->getPaymentId());
+    }
+
+    public function testThatFetchPaymentEventsThrowsApiErrorExceptionForErrorResponse()
+    {
+        $this->expectException(ApiErrorResponseException::class);
+        $this->expectExceptionMessage(self::ERROR_DESCRIPTION);
+        $this->mockGovPayClient
+            ->method('get')
+            ->willReturn(
+                new ApiResponse(
+                    new GuzzleResponse(HttpStatusCodeEnum::BAD_REQUEST, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD))
+                )
+            );
+        $this->paymentRepository->fetchPaymentEvents(self::PAYMENT_PAYMENT_ID);
     }
 
     public function testItFetchesPaymentEventsForPayment()
@@ -72,13 +101,27 @@ class PaymentRepositoryTest extends AbstractTestCase
         $this->assertEquals(self::PAYMENT_PAYMENT_ID, $result[0]->getPaymentId());
     }
 
+    public function testThatFetchPaymentRefundsThrowsApiErrorExceptionForErrorResponse()
+    {
+        $this->expectException(ApiErrorResponseException::class);
+        $this->expectExceptionMessage(self::ERROR_DESCRIPTION);
+        $this->mockGovPayClient
+            ->method('get')
+            ->willReturn(
+                new ApiResponse(
+                    new GuzzleResponse(HttpStatusCodeEnum::BAD_REQUEST, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD))
+                )
+            );
+        $this->paymentRepository->fetchPaymentRefunds(self::PAYMENT_PAYMENT_ID);
+    }
+
     public function testItFetchesPaymentRefundsForPayment()
     {
         $this->mockGovPayClient
             ->method('get')
             ->willReturn(
                 new ApiResponse(
-                    new GuzzleResponse(HttpStatusCodeEnum::OK, [], json_encode(self::PAYMENT_REFUNDS_RESULTS_ARRAY))
+                    new GuzzleResponse(HttpStatusCodeEnum::OK, [], json_encode(self::PAYMENT_REFUNDS_RESULTS_ARRAY_WITH_PAYMENT_LINK))
                 )
             );
         $result = $this->paymentRepository->fetchPaymentRefunds(self::PAYMENT_PAYMENT_ID);
@@ -86,6 +129,20 @@ class PaymentRepositoryTest extends AbstractTestCase
         $this->assertTrue(isset($result[0]));
         $this->assertInstanceOf(Refund::class, $result[0]);
         $this->assertEquals(self::REFUND_REFUND_ID, $result[0]->getRefundId());
+    }
+
+    public function testThatFetchAllThrowsApiErrorExceptionForErrorResponse()
+    {
+        $this->expectException(ApiErrorResponseException::class);
+        $this->expectExceptionMessage(self::ERROR_DESCRIPTION);
+        $this->mockGovPayClient
+            ->method('get')
+            ->willReturn(
+                new ApiResponse(
+                    new GuzzleResponse(HttpStatusCodeEnum::BAD_REQUEST, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD))
+                )
+            );
+        $this->paymentRepository->fetchAll();
     }
 
     public function testThatFetchAllWithWithNoResponseDataReturnsEmptyPaginatedResults()

--- a/tests/unit/Repository/RefundRepositoryTest.php
+++ b/tests/unit/Repository/RefundRepositoryTest.php
@@ -9,6 +9,7 @@ use LBHounslow\GovPay\Client\Client as GovPayClient;
 use LBHounslow\GovPay\Entity\PaginatedResults;
 use LBHounslow\GovPay\Entity\Refund;
 use LBHounslow\GovPay\Enum\HttpStatusCodeEnum;
+use LBHounslow\GovPay\Exception\ApiErrorResponseException;
 use LBHounslow\GovPay\Repository\RefundRepository;
 use LBHounslow\GovPay\Response\ApiResponse;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -39,6 +40,20 @@ class RefundRepositoryTest extends AbstractTestCase
     public function testItReturnsEntityClass()
     {
         $this->assertEquals(Refund::class, $this->refundRepository->getEntityClass());
+    }
+
+    public function testThatFetchAllThrowsApiErrorExceptionForErrorResponse()
+    {
+        $this->expectException(ApiErrorResponseException::class);
+        $this->expectExceptionMessage(self::ERROR_DESCRIPTION);
+        $this->mockGovPayClient
+            ->method('get')
+            ->willReturn(
+                new ApiResponse(
+                    new GuzzleResponse(HttpStatusCodeEnum::BAD_REQUEST, [], json_encode(self::ERROR_RESPONSE_WITH_FIELD))
+                )
+            );
+        $this->refundRepository->fetchAll();
     }
 
     public function testThatFetchAllWithWithNoResponseDataReturnsEmptyPaginatedResults()


### PR DESCRIPTION
**Updates:**
- Added [ApiErrorResponseException](https://github.com/LBHounslow/govpay-client/blob/develop/src/Exception/ApiErrorResponseException.php) which takes `ApiResponse` as an argument and stores (and provides) error response information from the GOV.UK api.
- Updated [PaymentRepository](https://github.com/LBHounslow/govpay-client/blob/develop/src/Repository/PaymentRepository.php) and [RefundRepository](https://github.com/LBHounslow/govpay-client/blob/develop/src/Repository/RefundRepository.php) to throw this exception for an [unsuccessful](https://github.com/LBHounslow/govpay-client/blob/develop/src/Response/ApiResponse.php#L65) api responses.
- Updated unit tests and documentation to cover this new exception.
- Removed incorrect @throws tags from `post` and `get` methods in [Client](https://github.com/LBHounslow/govpay-client/blob/develop/src/Client/Client.php#L70).

**Fixes:**
- Added default empty string value for `paymentId` attribute in [Refund](https://github.com/LBHounslow/govpay-client/blob/develop/src/Entity/Refund.php#L12) entity.
- Added unit test coverage in [RefundTest](https://github.com/LBHounslow/govpay-client/blob/develop/tests/unit/Entity/RefundTest.php#L29) for both empty and populated `paymentId` attribute.

```
govpay-client % composer test
> ./vendor/bin/phpunit tests --colors
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.25
Configuration: /Users/brett/Code/govpay-client/phpunit.xml.dist

...............................................................  63 / 108 ( 58%)
.............................................                   108 / 108 (100%)

Time: 00:00.064, Memory: 10.00 MB

OK (108 tests, 293 assertions)
```