### PR TITLE
Hotfix - Fixed bug in PaymentRepository.setReference

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Run `composer test`
 
 ```
 Code Coverage Report:      
-  2021-12-09 13:43:46      
+  2022-02-13 15:57:50      
                            
  Summary:                  
   Classes: 65.38% (17/26)  
-  Methods: 87.61% (191/218)
-  Lines:   90.76% (501/552)
+  Methods: 88.48% (192/217)
+  Lines:   91.27% (502/550)
 ```
 
 ### Contributing

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.0",
+            "version": "7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "868b3571a039f0ebc11ac8f344f4080babe2cb94"
+                "reference": "ee0a041b1760e6a53d2a39c8c34115adc2af2c79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/868b3571a039f0ebc11ac8f344f4080babe2cb94",
-                "reference": "868b3571a039f0ebc11ac8f344f4080babe2cb94",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ee0a041b1760e6a53d2a39c8c34115adc2af2c79",
+                "reference": "ee0a041b1760e6a53d2a39c8c34115adc2af2c79",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
                 "guzzlehttp/psr7": "^1.8.3 || ^2.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2"
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -112,7 +112,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.1"
             },
             "funding": [
                 {
@@ -128,7 +128,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-18T09:52:00+00:00"
+            "time": "2021-12-06T18:43:05+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -535,16 +535,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.4.0",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
-                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
                 "shasum": ""
             },
             "require": {
@@ -553,7 +553,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -582,7 +582,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
             },
             "funding": [
                 {
@@ -598,7 +598,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-23T23:28:01+00:00"
+            "time": "2021-07-12T14:48:14+00:00"
         }
     ],
     "packages-dev": [
@@ -698,12 +698,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -731,16 +731,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.1",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/63a79e8daa781cac14e5195e63ed8ae231dd10fd",
-                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -781,9 +781,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
             },
-            "time": "2021-11-03T20:52:16+00:00"
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -847,16 +847,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+                "reference": "15a90844ad40f127afd244c0cad228de2a80052a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/15a90844ad40f127afd244c0cad228de2a80052a",
+                "reference": "15a90844ad40f127afd244c0cad228de2a80052a",
                 "shasum": ""
             },
             "require": {
@@ -892,9 +892,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.0"
+                "source": "https://github.com/phar-io/version/tree/3.1.1"
             },
-            "time": "2021-02-23T14:00:09+00:00"
+            "time": "2022-02-07T21:56:48+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1008,16 +1008,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
-                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
                 "shasum": ""
             },
             "require": {
@@ -1052,22 +1052,22 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
             },
-            "time": "2021-10-02T14:08:47+00:00"
+            "time": "2022-01-04T19:58:01+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
                 "shasum": ""
             },
             "require": {
@@ -1119,22 +1119,22 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
-            "time": "2021-09-10T09:02:12+00:00"
+            "time": "2021-12-08T12:19:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.8",
+            "version": "9.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "cf04e88a2e3c56fc1a65488afd493325b4c1bc3e"
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/cf04e88a2e3c56fc1a65488afd493325b4c1bc3e",
-                "reference": "cf04e88a2e3c56fc1a65488afd493325b4c1bc3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
                 "shasum": ""
             },
             "require": {
@@ -1190,7 +1190,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.8"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
             },
             "funding": [
                 {
@@ -1198,20 +1198,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-30T08:01:38+00:00"
+            "time": "2021-12-05T09:12:13+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
@@ -1250,7 +1250,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -1258,7 +1258,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:57:25+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -1443,16 +1443,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.10",
+            "version": "9.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a"
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
-                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/597cb647654ede35e43b137926dfdfef0fb11743",
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743",
                 "shasum": ""
             },
             "require": {
@@ -1503,11 +1503,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1530,11 +1530,11 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.10"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.13"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/donate.html",
+                    "url": "https://phpunit.de/sponsors.html",
                     "type": "custom"
                 },
                 {
@@ -1542,7 +1542,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-09-25T07:38:51+00:00"
+            "time": "2022-01-24T07:33:35+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1973,16 +1973,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
@@ -2031,14 +2031,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
             },
             "funding": [
                 {
@@ -2046,20 +2046,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.3",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+                "reference": "19c519631c5a511b7ed0ad64a6713fdb3fd25fe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/19c519631c5a511b7ed0ad64a6713fdb3fd25fe4",
+                "reference": "19c519631c5a511b7ed0ad64a6713fdb3fd25fe4",
                 "shasum": ""
             },
             "require": {
@@ -2102,7 +2102,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.4"
             },
             "funding": [
                 {
@@ -2110,7 +2110,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-11T13:31:12+00:00"
+            "time": "2022-02-10T07:01:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -2510,20 +2510,23 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.23.0",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -2569,7 +2572,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -2585,7 +2588,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-10-20T20:35:02+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog
 
+### Release v1.3.0 `13/02/2022`
+
+Fixes:
+- Added fix for `PaymentRepository->setReference()` method.
+
+Updates:
+- Additional unit test coverage added for setters and getters in all entities.
+
 ### Release v1.2.0 `09/12/2021`
 
 Updates:

--- a/src/Entity/CardDetails.php
+++ b/src/Entity/CardDetails.php
@@ -39,12 +39,12 @@ class CardDetails implements ArrayToEntityInterface
     /**
      * @var string
      */
-    private $lastDigitsCardNumber = '';
+    private $firstDigitsCardNumber = '';
 
     /**
      * @var string
      */
-    private $firstDigitsCardNumber = '';
+    private $lastDigitsCardNumber = '';
 
     /**
      * @var string
@@ -100,24 +100,6 @@ class CardDetails implements ArrayToEntityInterface
     /**
      * @return string
      */
-    public function getLastDigitsCardNumber(): string
-    {
-        return $this->lastDigitsCardNumber;
-    }
-
-    /**
-     * @param string $lastDigitsCardNumber
-     * @return CardDetails
-     */
-    public function setLastDigitsCardNumber(string $lastDigitsCardNumber): CardDetails
-    {
-        $this->lastDigitsCardNumber = $lastDigitsCardNumber;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
     public function getFirstDigitsCardNumber(): string
     {
         return $this->firstDigitsCardNumber;
@@ -130,6 +112,24 @@ class CardDetails implements ArrayToEntityInterface
     public function setFirstDigitsCardNumber(string $firstDigitsCardNumber): CardDetails
     {
         $this->firstDigitsCardNumber = $firstDigitsCardNumber;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastDigitsCardNumber(): string
+    {
+        return $this->lastDigitsCardNumber;
+    }
+
+    /**
+     * @param string $lastDigitsCardNumber
+     * @return CardDetails
+     */
+    public function setLastDigitsCardNumber(string $lastDigitsCardNumber): CardDetails
+    {
+        $this->lastDigitsCardNumber = $lastDigitsCardNumber;
         return $this;
     }
 

--- a/src/Repository/PaymentRepository.php
+++ b/src/Repository/PaymentRepository.php
@@ -43,7 +43,7 @@ class PaymentRepository extends BaseEntityRepository
      */
     public function setReference(string $reference): PaymentRepository
     {
-        $this->queryStringBuilder->$this->setReference($reference);
+        $this->queryStringBuilder->setReference($reference);
         return $this;
     }
 

--- a/tests/unit/Builder/QueryStringBuilderTest.php
+++ b/tests/unit/Builder/QueryStringBuilderTest.php
@@ -22,6 +22,26 @@ class QueryStringBuilderTest extends AbstractTestCase
     }
 
     /**
+     * @doesNotPerformAssertions
+     */
+    public function testSetters()
+    {
+        $this->queryStringBuilder->setPage(1);
+        $this->queryStringBuilder->setPerPage(20);
+        $this->queryStringBuilder->setFromDate('2022-02-09 00:00:00');
+        $this->queryStringBuilder->setToDate('2022-02-10 00:00:00');
+        $this->queryStringBuilder->setFromSettledDate('2022-02-09');
+        $this->queryStringBuilder->setToSettledDate('2022-02-10');
+        $this->queryStringBuilder->setEmail('test@domain.com');
+        $this->queryStringBuilder->setReference('reference-123');
+        $this->queryStringBuilder->setState('success');
+        $this->queryStringBuilder->setCardBrand('visa');
+        $this->queryStringBuilder->setCardholderName('Test Person');
+        $this->queryStringBuilder->setFirstDigitsCardNumber('1234');
+        $this->queryStringBuilder->setLastDigitsCardNumber('7890');
+    }
+
+    /**
      * @param string $attribute
      * @param mixed $value
      * @param string $expectedQueryString

--- a/tests/unit/Entity/AuthorisationSummaryTest.php
+++ b/tests/unit/Entity/AuthorisationSummaryTest.php
@@ -20,6 +20,12 @@ class AuthorisationSummaryTest extends AbstractTestCase
         parent::setUp();
     }
 
+    public function testSettersAndGetters()
+    {
+        $this->authorisationSummary->setThreeDSecureRequired(true);
+        $this->assertTrue($this->authorisationSummary->isThreeDSecureRequired());
+    }
+
     public function testThatEntityLoadsWithEmptyArray()
     {
         $result = $this->authorisationSummary->fromArray([]);

--- a/tests/unit/Entity/CardBillingAddressTest.php
+++ b/tests/unit/Entity/CardBillingAddressTest.php
@@ -20,6 +20,24 @@ class CardBillingAddressTest extends AbstractTestCase
         parent::setUp();
     }
 
+    public function testSettersAndGetters()
+    {
+        $this->cardBillingAddress->setLine1('Line 1');
+        $this->assertEquals('Line 1', $this->cardBillingAddress->getLine1());
+
+        $this->cardBillingAddress->setLine2('Line 2');
+        $this->assertEquals('Line 2', $this->cardBillingAddress->getLine2());
+
+        $this->cardBillingAddress->setCity('City');
+        $this->assertEquals('City', $this->cardBillingAddress->getCity());
+
+        $this->cardBillingAddress->setCountry('Country');
+        $this->assertEquals('Country', $this->cardBillingAddress->getCountry());
+
+        $this->cardBillingAddress->setPostCode('TW3 3EB');
+        $this->assertEquals('TW3 3EB', $this->cardBillingAddress->getPostCode());
+    }
+
     public function testThatEntityLoadsWithEmptyArray()
     {
         $result = $this->cardBillingAddress->fromArray([]);

--- a/tests/unit/Entity/CardDetailsTest.php
+++ b/tests/unit/Entity/CardDetailsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Entity;
 
+use LBHounslow\GovPay\Entity\CardBillingAddress;
 use LBHounslow\GovPay\Entity\CardDetails;
 use Tests\Unit\AbstractTestCase;
 
@@ -18,6 +19,30 @@ class CardDetailsTest extends AbstractTestCase
     {
         $this->cardDetails = new CardDetails();
         parent::setUp();
+    }
+
+    public function testSettersAndGetters()
+    {
+        $this->cardDetails->setCardBrand('visa');
+        $this->assertEquals('visa', $this->cardDetails->getCardBrand());
+
+        $this->cardDetails->setCardType('debit');
+        $this->assertEquals('debit', $this->cardDetails->getCardType());
+
+        $this->cardDetails->setFirstDigitsCardNumber('1234');
+        $this->assertEquals('1234', $this->cardDetails->getFirstDigitsCardNumber());
+
+        $this->cardDetails->setLastDigitsCardNumber('7890');
+        $this->assertEquals('7890', $this->cardDetails->getLastDigitsCardNumber());
+
+        $this->cardDetails->setExpiryDate('09/29');
+        $this->assertEquals('09/29', $this->cardDetails->getExpiryDate());
+
+        $this->cardDetails->setCardHolderName('Test Person');
+        $this->assertEquals('Test Person', $this->cardDetails->getCardHolderName());
+
+        $this->cardDetails->setCardBillingAddress(new CardBillingAddress());
+        $this->assertInstanceOf(CardBillingAddress::class, $this->cardDetails->getCardBillingAddress());
     }
 
     public function testThatEntityLoadsWithEmptyArray()

--- a/tests/unit/Entity/LinkTest.php
+++ b/tests/unit/Entity/LinkTest.php
@@ -20,6 +20,24 @@ class LinkTest extends AbstractTestCase
         parent::setUp();
     }
 
+    public function testSettersAndGetters()
+    {
+        $this->link->setName('link name');
+        $this->assertEquals('link name', $this->link->getName());
+
+        $this->link->setType('type');
+        $this->assertEquals('type', $this->link->getType());
+
+        $this->link->setParams([1,2,3]);
+        $this->assertEquals([1,2,3], $this->link->getParams());
+
+        $this->link->setHref('http://test.url');
+        $this->assertEquals('http://test.url', $this->link->getHref());
+
+        $this->link->setMethod('method');
+        $this->assertEquals('method', $this->link->getMethod());
+    }
+
     public function testThatEntityLoadsWithEmptyArray()
     {
         $result = $this->link->fromArray([]);

--- a/tests/unit/Entity/PaymentEventTest.php
+++ b/tests/unit/Entity/PaymentEventTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Entity;
 
 use LBHounslow\GovPay\Entity\PaymentEvent;
+use LBHounslow\GovPay\Entity\PaymentState;
 use Tests\Unit\AbstractTestCase;
 
 class PaymentEventTest extends AbstractTestCase
@@ -18,6 +19,18 @@ class PaymentEventTest extends AbstractTestCase
     {
         $this->paymentEvent = new PaymentEvent();
         parent::setUp();
+    }
+
+    public function testSettersAndGetters()
+    {
+        $this->paymentEvent->setPaymentId('payment-id');
+        $this->assertEquals('payment-id', $this->paymentEvent->getPaymentId());
+
+        $this->paymentEvent->setUpdated('09-02-2022');
+        $this->assertEquals('09-02-2022', $this->paymentEvent->getUpdated());
+
+        $this->paymentEvent->setState(new PaymentState());
+        $this->assertInstanceOf(PaymentState::class, $this->paymentEvent->getState());
     }
 
     public function testThatEntityLoadsWithEmptyArray()

--- a/tests/unit/Entity/PaymentStateTest.php
+++ b/tests/unit/Entity/PaymentStateTest.php
@@ -26,6 +26,21 @@ class PaymentStateTest extends AbstractTestCase
         $this->assertInstanceOf(PaymentState::class, $result);
     }
 
+    public function testSettersAndGetters()
+    {
+        $this->paymentState->setStatus('success');
+        $this->assertEquals('success', $this->paymentState->getStatus());
+
+        $this->paymentState->setFinished(true);
+        $this->assertTrue($this->paymentState->isFinished());
+
+        $this->paymentState->setMessage('here is a message');
+        $this->assertEquals('here is a message', $this->paymentState->getMessage());
+
+        $this->paymentState->setCode('400');
+        $this->assertEquals('400', $this->paymentState->getCode());
+    }
+
     public function testThatEntityLoadsRefundSummaryDataCorrectly()
     {
         $result = $this->paymentState->fromArray(

--- a/tests/unit/Entity/PaymentTest.php
+++ b/tests/unit/Entity/PaymentTest.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Entity;
 
+use LBHounslow\GovPay\Entity\AuthorisationSummary;
+use LBHounslow\GovPay\Entity\CardDetails;
+use LBHounslow\GovPay\Entity\Link;
 use LBHounslow\GovPay\Entity\Payment;
+use LBHounslow\GovPay\Entity\PaymentState;
+use LBHounslow\GovPay\Entity\RefundSummary;
+use LBHounslow\GovPay\Entity\SettlementSummary;
 use Tests\Unit\AbstractTestCase;
 
 class PaymentTest extends AbstractTestCase
@@ -18,6 +24,78 @@ class PaymentTest extends AbstractTestCase
     {
         $this->payment = new Payment();
         parent::setUp();
+    }
+
+    public function testSettersAndGetters()
+    {
+        $this->payment->setCreatedDate('2022-02-09 00:00:00');
+        $this->assertEquals('2022-02-09 00:00:00', $this->payment->getCreatedDate());
+
+        $this->payment->setAmount(123);
+        $this->assertEquals(123, $this->payment->getAmount());
+
+        $this->payment->setState(new PaymentState());
+        $this->assertInstanceOf(PaymentState::class, $this->payment->getState());
+
+        $this->payment->setDescription('description');
+        $this->assertEquals('description', $this->payment->getDescription());
+
+        $this->payment->setReference('payment-ref');
+        $this->assertEquals('payment-ref', $this->payment->getReference());
+
+        $this->payment->setLanguage('en');
+        $this->assertEquals('en', $this->payment->getLanguage());
+
+        $this->payment->setData([1, 2, 3]);
+        $this->assertEquals([1, 2, 3], $this->payment->getData());
+
+        $this->payment->setEmail('test@domain.com');
+        $this->assertEquals('test@domain.com', $this->payment->getEmail());
+
+        $this->payment->setCardDetails(new CardDetails());
+        $this->assertInstanceOf(CardDetails::class, $this->payment->getCardDetails());
+
+        $this->payment->setRefundSummary(new RefundSummary());
+        $this->assertInstanceOf(RefundSummary::class, $this->payment->getRefundSummary());
+
+        $this->payment->setSettlementSummary(new SettlementSummary());
+        $this->assertInstanceOf(SettlementSummary::class, $this->payment->getSettlementSummary());
+
+        $this->payment->setDelayedCapture(true);
+        $this->assertTrue($this->payment->isDelayedCapture());
+
+        $this->payment->setMoto(true);
+        $this->assertTrue($this->payment->isMoto());
+
+        $this->payment->setCorporateCardSurcharge(123);
+        $this->assertEquals(123, $this->payment->getCorporateCardSurcharge());
+
+        $this->payment->setTotalAmount(123);
+        $this->assertEquals(123, $this->payment->getTotalAmount());
+
+        $this->payment->setFee(123);
+        $this->assertEquals(123, $this->payment->getFee());
+
+        $this->payment->setNetAmount(123);
+        $this->assertEquals(123, $this->payment->getNetAmount());
+
+        $this->payment->setPaymentProvider('payment-provider');
+        $this->assertEquals('payment-provider', $this->payment->getPaymentProvider());
+
+        $this->payment->setProviderId('provider-id');
+        $this->assertEquals('provider-id', $this->payment->getProviderId());
+
+        $this->payment->setPaymentId('payment-id');
+        $this->assertEquals('payment-id', $this->payment->getPaymentId());
+
+        $this->payment->setAuthorisationSummary(new AuthorisationSummary());
+        $this->assertInstanceOf(AuthorisationSummary::class, $this->payment->getAuthorisationSummary());
+
+        $this->payment->setReturnUrl('https://test.url');
+        $this->assertEquals('https://test.url', $this->payment->getReturnUrl());
+
+        $this->payment->setLinks([(new Link())->setHref('https://test.url')]);
+        $this->assertEquals([(new Link())->setHref('https://test.url')], $this->payment->getLinks());
     }
 
     public function testThatEntityLoadsWithEmptyArray()

--- a/tests/unit/Entity/RefundSummaryTest.php
+++ b/tests/unit/Entity/RefundSummaryTest.php
@@ -20,6 +20,18 @@ class RefundSummaryTest extends AbstractTestCase
         parent::setUp();
     }
 
+    public function testSettersAndGetters()
+    {
+        $this->refundSummary->setStatus('success');
+        $this->assertEquals('success', $this->refundSummary->getStatus());
+
+        $this->refundSummary->setAmountAvailable(123);
+        $this->assertEquals(123, $this->refundSummary->getAmountAvailable());
+
+        $this->refundSummary->setAmountSubmitted(123);
+        $this->assertEquals(123, $this->refundSummary->getAmountSubmitted());
+    }
+
     public function testThatEntityLoadsWithEmptyArray()
     {
         $result = $this->refundSummary->fromArray([]);

--- a/tests/unit/Entity/RefundTest.php
+++ b/tests/unit/Entity/RefundTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Entity;
 
 use LBHounslow\GovPay\Entity\Refund;
+use LBHounslow\GovPay\Entity\SettlementSummary;
 use Tests\Unit\AbstractTestCase;
 
 class RefundTest extends AbstractTestCase
@@ -18,6 +19,27 @@ class RefundTest extends AbstractTestCase
     {
         $this->refund = new Refund();
         parent::setUp();
+    }
+
+    public function testSettersAndGetters()
+    {
+        $this->refund->setPaymentId('payment-id');
+        $this->assertEquals('payment-id', $this->refund->getPaymentId());
+
+        $this->refund->setRefundId('refund-id');
+        $this->assertEquals('refund-id', $this->refund->getRefundId());
+
+        $this->refund->setCreatedDate('2022-02-09');
+        $this->assertEquals('2022-02-09', $this->refund->getCreatedDate());
+
+        $this->refund->setAmount(123);
+        $this->assertEquals(123, $this->refund->getAmount());
+
+        $this->refund->setStatus('finished');
+        $this->assertEquals('finished', $this->refund->getStatus());
+
+        $this->refund->setSettlementSummary(new SettlementSummary());
+        $this->assertInstanceOf(SettlementSummary::class, $this->refund->getSettlementSummary());
     }
 
     public function testThatEntityLoadsWithEmptyArray()

--- a/tests/unit/Entity/SettlementSummaryTest.php
+++ b/tests/unit/Entity/SettlementSummaryTest.php
@@ -20,6 +20,18 @@ class SettlementSummaryTest extends AbstractTestCase
         parent::setUp();
     }
 
+    public function testSettersAndGetters()
+    {
+        $this->settlementSummary->setCaptureSubmitTime('2022-02-09');
+        $this->assertEquals('2022-02-09', $this->settlementSummary->getCaptureSubmitTime());
+
+        $this->settlementSummary->setCapturedDate('2022-02-09');
+        $this->assertEquals('2022-02-09', $this->settlementSummary->getCapturedDate());
+
+        $this->settlementSummary->setSettledDate('2022-02-09');
+        $this->assertEquals('2022-02-09', $this->settlementSummary->getSettledDate());
+    }
+
     public function testThatEntityLoadsWithEmptyArray()
     {
         $result = $this->settlementSummary->fromArray([]);

--- a/tests/unit/Enum/DateFormatEnumTest.php
+++ b/tests/unit/Enum/DateFormatEnumTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enum;
+
+use LBHounslow\GovPay\Enum\DateFormatEnum;
+use Tests\Unit\AbstractTestCase;
+
+class DateFormatEnumTest extends AbstractTestCase
+{
+    public function testItConstructs()
+    {
+        $dateFormatEnum = new DateFormatEnum();
+        $this->assertInstanceOf(DateFormatEnum::class, $dateFormatEnum);
+    }
+}

--- a/tests/unit/Enum/HttpStatusCodeEnumTest.php
+++ b/tests/unit/Enum/HttpStatusCodeEnumTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enum;
+
+use LBHounslow\GovPay\Enum\HttpStatusCodeEnum;
+use Tests\Unit\AbstractTestCase;
+
+class HttpStatusCodeEnumTest extends AbstractTestCase
+{
+    public function testItConstructs()
+    {
+        $httpStatusCodeEnum = new HttpStatusCodeEnum();
+        $this->assertInstanceOf(HttpStatusCodeEnum::class, $httpStatusCodeEnum);
+    }
+}

--- a/tests/unit/Repository/PaymentRepositoryTest.php
+++ b/tests/unit/Repository/PaymentRepositoryTest.php
@@ -44,6 +44,20 @@ class PaymentRepositoryTest extends AbstractTestCase
         $this->assertEquals(Payment::class, $this->paymentRepository->getEntityClass());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testSetters()
+    {
+        $this->paymentRepository->setCardBrand('visa');
+        $this->paymentRepository->setReference('reference-123');
+        $this->paymentRepository->setEmail('test@domain.com');
+        $this->paymentRepository->setCardholderName('Test Person');
+        $this->paymentRepository->setState('success');
+        $this->paymentRepository->setFirstDigitsCardNumber('1234');
+        $this->paymentRepository->setLastDigitsCardNumber('7890');
+    }
+
     public function testThatFindThrowsApiErrorExceptionForErrorResponse()
     {
         $this->expectException(ApiErrorResponseException::class);


### PR DESCRIPTION
Fixed: `PaymentRepository->setReference()` issue in setter (`$this->queryStringBuilder->$this->setReference($reference)`) [here](https://github.com/LBHounslow/govpay-client/pull/5/files#diff-5f0845c70e8655e126e891dd5c0883376f29259e8755db922f8e985fc6413a05L46)

Improved test coverage by adding getter and setter coverage to all entities (as well as `QueryStringBuilder`)

```
./vendor/bin/phpunit
PHPUnit 9.5.13 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.25 with Xdebug 3.1.1
Configuration: /Users/brett/Code/govpay-client/phpunit.xml.dist

...............................................................  63 / 122 ( 51%)
...........................................................     122 / 122 (100%)

Time: 00:00.473, Memory: 16.00 MB

OK (122 tests, 355 assertions)
```